### PR TITLE
Show supported SDK version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 #  In-App Payments Quick Start Sample iOS Application
 
+## Supported SDK version
+
+* In-App Payments SDK: `1.6.5`
+
 Follow the [In-App Payments Quick Start Guide](https://docs.connect.squareup.com/payments/in-app-payments-sdk/quickstart/start) to take payments in an app running on a buyer's personal mobile device.
 
 ## License


### PR DESCRIPTION
## Summary
- Add SDK version section to README so the current version (`1.6.5`) is obvious at a glance

## Test plan
- [x] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)