### PR TITLE
Bump In-App Payments SDK to 1.6.6

### DIFF
--- a/InAppPaymentsSample.xcodeproj/project.pbxproj
+++ b/InAppPaymentsSample.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 			repositoryURL = "https://github.com/square/in-app-payments-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.6.5;
+				minimumVersion = 1.6.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Supported SDK version
 
-* In-App Payments SDK: `1.6.5`
+* In-App Payments SDK: `1.6.6`
 
 Follow the [In-App Payments Quick Start Guide](https://docs.connect.squareup.com/payments/in-app-payments-sdk/quickstart/start) to take payments in an app running on a buyer's personal mobile device.
 


### PR DESCRIPTION
## Summary
Bump the SquareInAppPaymentsSDK Swift Package dependency to 1.6.6.

The 1.6.6 release updates the bundled NetceteraSDK to 2.5.1.0 to address the Visa Device Data Encryption Certificate expiration on 2026-06-08.

## Changes
- `README.md` — supported SDK version `1.6.5` → `1.6.6`
- `InAppPaymentsSample.xcodeproj/project.pbxproj` — Swift Package `minimumVersion` `1.6.5` → `1.6.6`

## Test plan
- [x] `pod install` resolves cleanly (n/a — quickstart uses SPM)
- [x] Xcode resolves the new package version
- [x] Sample app builds and runs against 1.6.6