### PR TITLE
Bump In-App Payments SDK to 1.6.7

### DIFF
--- a/InAppPaymentsSample.xcodeproj/project.pbxproj
+++ b/InAppPaymentsSample.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 			repositoryURL = "https://github.com/square/in-app-payments-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.6.6;
+				minimumVersion = 1.6.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/InAppPaymentsSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InAppPaymentsSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/square/in-app-payments-ios",
       "state" : {
-        "revision" : "bf5989c11c4086170b3cefc3a853c64d985aeb10",
-        "version" : "1.6.5"
+        "revision" : "386889b41c945b64a147a2999823356c0883504e",
+        "version" : "1.6.7"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Supported SDK version
 
-* In-App Payments SDK: `1.6.6`
+* In-App Payments SDK: `1.6.7`
 
 Follow the [In-App Payments Quick Start Guide](https://docs.connect.squareup.com/payments/in-app-payments-sdk/quickstart/start) to take payments in an app running on a buyer's personal mobile device.
 


### PR DESCRIPTION
## Summary
Bump the bundled In-App Payments SDK from `1.6.6` to `1.6.7`.

1.6.7 is a packaging-only patch on top of 1.6.6 that fixes public-header imports in the shipped `SquareInAppPaymentsSDK` and `SquareBuyerVerificationSDK` xcframeworks — system-framework imports were using `@import` (Clang modules) which failed to resolve in some consumer build contexts. **No API or behavior changes vs 1.6.6.**

## Changes
- `README.md` — supported SDK version `1.6.6` → `1.6.7`
- `InAppPaymentsSample.xcodeproj/project.pbxproj` — SPM `minimumVersion` `1.6.6` → `1.6.7`
- `…/Package.resolved` — pinned revision/version updated to the `1.6.7` tag commit (`386889b`); the existing `Package.resolved` was still at `1.6.5` so this is effectively a `1.6.5` → `1.6.7` SPM resolve, which Xcode will redo on first open.